### PR TITLE
fix 'or' resolver

### DIFF
--- a/test/unit/helper_spec.js
+++ b/test/unit/helper_spec.js
@@ -172,6 +172,18 @@ describe('(unit) src/helper.js', () => {
           expect(r1.handle.calledOnce).to.be.true;
         });
       });
+
+      it('(true, false) should return local error from wrapped resolver', () => {
+        const resolver = or(successResolver, failureResolver);
+        const localError = new Error('test');
+        const finalResolver = resolver(() => {
+          throw localError;
+        });
+        return finalResolver()
+          .catch(err => {
+            expect(err).to.equal(localError);
+          });
+      });
     });
 
   });


### PR DESCRIPTION
if wrapped component thrown an error, this error should be returned
cover local error case with unit test

ref: https://github.com/thebigredgeek/apollo-resolvers/issues/46